### PR TITLE
Minor content changes

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,13 +12,13 @@ GOV.UK Universal Content Type
     <div class="govuk-grid-column-two-thirds">
 
 
-        <h2 class="govuk-heading-m">Standard content template, front-end prototype – guidance example</h2>
+        <h2 class="govuk-heading-m">Standard content template, frontend prototype – guidance example</h2>
 
 
         <p class="govuk-body-m">
-          We believe GOV.UK could be using a reduced set of flexible and consistent front end templates, which broadly map to our work on typology.</p>
+          We believe GOV.UK could be using a reduced set of flexible and consistent frontend templates, which broadly map to our work on typology.</p>
 
-         <p>The standard content template would be the most used across GOV.UK, so we've brought the concept to life in this front end prototype.</p>
+         <p>The standard content template would be the most used across GOV.UK, so we've brought the concept to life in this frontend prototype.</p>
         <p> We've also used the prototype to demonstrate how we could merge 4 guidance content types (across different schemas) into one flexible 'guidance' content type.
           <a href="https://docs.google.com/document/d/1PpYxEd28ru1YsL31riz0nOyEtkauxwx6wfv5UpQL758/edit#">Read more about why we chose guidance</a></p>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,13 +12,13 @@ GOV.UK Universal Content Type
     <div class="govuk-grid-column-two-thirds">
 
 
-        <h2 class="govuk-heading-m">Standalone content template, front-end prototype – guidance example</h2>
+        <h2 class="govuk-heading-m">Standard content template, front-end prototype – guidance example</h2>
 
 
         <p class="govuk-body-m">
           We believe GOV.UK could be using a reduced set of flexible and consistent front end templates, which broadly map to our work on typology.</p>
 
-         <p>The standalone content template would be the most used across GOV.UK, so we've brought the concept to life in this front end prototype.</p>
+         <p>The standard content template would be the most used across GOV.UK, so we've brought the concept to life in this front end prototype.</p>
         <p> We've also used the prototype to demonstrate how we could merge 4 guidance content types (across different schemas) into one flexible 'guidance' content type.
           <a href="https://docs.google.com/document/d/1PpYxEd28ru1YsL31riz0nOyEtkauxwx6wfv5UpQL758/edit#">Read more about why we chose guidance</a></p>
 


### PR DESCRIPTION
- Change "standalone" to "standard" in two instances on the index, requested by Sally Creasey: "We're now using 'standard' instead of 'standalone' - as nothing is really standalone on [GOV.UK](http://gov.uk/)" 
- Change formatting of the word "frontend"

<img width="1007" alt="Screenshot 2022-12-16 at 11 59 13" src="https://user-images.githubusercontent.com/90854/208093611-4daecbd1-05d8-42ce-a1e9-956b58a5e564.png">
